### PR TITLE
Migrate runtime to params-return API and generate module-level sealed deeplink params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - `DeeplinkProcessor.Builder.register(...)` now registers only a `DeeplinkSpec`:
   - Before: `register(spec: DeeplinkSpec, handler: DeeplinkHandler<T>)`
   - Now: `register(spec: DeeplinkSpec)`
+- `deepmatch-plugin` now generates a module-level sealed params interface named from the module
+  name (for example, module `app` -> `AppDeeplinkParams`).
+- Generated `*DeeplinkParams` classes now implement the module-level sealed params interface,
+  allowing exhaustive `when` checks when matching deeplinks.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ and it will:
 
 - Generate strongly-typed deeplink specs (plus parameter classes when the link declares template,
   query, or fragment values).
+- Generate a module-level sealed params interface (for example, module `app` generates
+  `AppDeeplinkParams`) that all generated params classes implement.
 - Optionally emit manifest snippets so you never hand-write `<intent-filter>` entries again.
 - Provide a lightweight runtime (`deepmatch-processor`) that matches URIs against the generated
   specs and returns typed params.
@@ -80,11 +82,11 @@ For full documentation please visit our [official docs page](https://aouledissa.
        .build()
 
    intent.data?.let { uri ->
-       when (val params = processor.match(uri)) {
+       val params = processor.match(uri)
+       when (params) {
            is OpenSeriesDeeplinkParams -> {
                // Perform navigation/business logic using params.
-           }
-           else -> Unit
+           } // Exhaustive when over your generated params types.
        }
    }
    ```

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/config/AndroidVariantsConfig.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/config/AndroidVariantsConfig.kt
@@ -48,6 +48,7 @@ private fun registerDeeplinkSpecsSourcesTask(
     ) {
         it.specsFileProperty.set(specsFile)
         it.packageNameProperty.set(variantPackageName)
+        it.moduleNameProperty.set(project.name)
     }
 
     /**

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/config/MissingSpecsFileException.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/config/MissingSpecsFileException.kt
@@ -6,7 +6,7 @@ internal class MissingSpecsFileException(
     private val path: String,
     private val variantName: String
 ) : GradleException() {
-    override val message: String?
+    override val message: String
         get() = """
                 DeepMatch Configuration Error: Failed to find the '.deeplinks.yml' deeplink specification file.
                 To resolve this, create a '.deeplinks.yml' file in ONE of the following locations (checked in this order):

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -86,3 +86,4 @@ deeplinkSpecs:
 - Regenerate sources (`./gradlew generate<Variant>DeeplinkSpecs`) whenever you modify the YAML schema.
 - If `generateManifestFiles` is disabled, remember to replicate the `<intent-filter>` changes manually in your main manifest.
 - When a deeplink declares typed path, query, or fragment values, the plugin also creates a `<Name>DeeplinkParams` class so your app receives strongly typed arguments after calling `match(uri)`.
+- All generated params classes implement a module-level sealed interface named from the module name (for example, module `app` -> `AppDeeplinkParams`), enabling exhaustive `when` checks.

--- a/docs/gradle_plugin.md
+++ b/docs/gradle_plugin.md
@@ -14,8 +14,8 @@ The primary responsibilities and capabilities of the DeepMatch Gradle plugin are
 
 3.  **Code Generation (`DeeplinkSpecs`):**
     *   The plugin generates Kotlin source code, most notably a class named something like `[DeeplinkName]DeeplinkSpecs` (the exact name might vary based on the deeplink name in the `.yml` file).
-    *   The plugin also generates another Kotlin source for the dynamic params in the configured deeplink. This means if any of your deeplink's **path parameters** is pattern-based or if the deeplink contains at least one **query parameter**, a parameter class will be generated.
-    *   This makes it easy to access these parameters later when matching and handling the deeplink. 
+    *   The plugin also generates params classes for deeplinks with typed path/query/fragment values.
+    *   It additionally generates a module-level sealed interface (for example, module `app` -> `AppDeeplinkParams`) implemented by all generated params classes, enabling exhaustive `when` matching in app code.
 
 4.  **Integration with Build Process:**
     *   The plugin hooks into the Android Gradle Plugin's build lifecycle.
@@ -23,7 +23,6 @@ The primary responsibilities and capabilities of the DeepMatch Gradle plugin are
 
 5.  **Configuration Options:**
     *   The plugin provides a DSL (Domain Specific Language) extension in your `build.gradle` (`deepMatch { ... }` block) to customize its behavior:
-        *   **specsFile:** Specifying a custom path to your `.deeplinks.yml` file if it's not in the default location.
         *   **generateManifestFiles:** Specifying whether or not the plugin should generate `AndroidManifest.xml` file based on the deeplink config `yaml` file.
 
 ### Benefits of Using the Plugin
@@ -60,6 +59,7 @@ During the build the plugin generates Kotlin sources under `build/generated/` an
 
 ### Generated Artifacts
 
+- `<ModuleName>DeeplinkParams.kt` — module-level sealed interface implemented by generated params classes.
 - `*DeeplinkSpecs.kt` — exposes a `DeeplinkSpec` property per configuration entry.
 - `*DeeplinkParams.kt` — optional data class emitted when a deeplink defines typed template, query, or fragment parameters.
 - Generated manifest file — contains `<intent-filter>` definitions that Gradle merges into the final manifest.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,8 @@ runtime library matches incoming URIs and returns strongly-typed params.
 1. Apply the plugin alongside your Android/Kotlin plugins and enable manifest generation if desired.
 2. Describe deeplinks in `.deeplinks.yml`; both module-level and variant-specific files are supported.
 3. Register generated specs with `DeeplinkProcessor` and call `match(uri)` at runtime to retrieve
-   parsed params.
+   parsed params. Generated params classes share a module-level sealed interface (for example,
+   `AppDeeplinkParams`) so your app can use exhaustive `when` matching.
 
 For detailed configuration options, see the navigation links for the Gradle plugin and YAML schema.
 


### PR DESCRIPTION
## Summary

  This PR introduces the new deeplink runtime flow and aligns code generation/docs with it.

  - Refactors deepmatch-processor to return params from matching:
      - DeeplinkProcessor.match(uri): DeeplinkParams?
      - DeeplinkProcessor.Builder.register(spec)
  - Removes handler-based runtime API usage (DeeplinkHandler dispatch path).
  - Updates plugin codegen to emit one sealed interface per module:
      - <ModuleName>DeeplinkParams (example: module app -> AppDeeplinkParams)
  - Ensures generated *DeeplinkParams classes implement the module sealed interface.
  - Keeps generation KotlinPoet-based.
  - Updates tests/fakes to match the new API.
  - Updates README.md and docs to show sealed-interface + exhaustive when flow.
  - Appends CHANGELOG.md (Unreleased) with these changes and migration notes.

  ## Breaking Changes

  - match(uri, activity) -> match(uri): DeeplinkParams?
  - register(spec, handler) -> register(spec)
  - Handler-based dispatch removed from processor public API.

  ## Migration

  Before:

  val processor = DeeplinkProcessor.Builder()
      .register(OpenSeriesDeeplinkSpecs, OpenSeriesDeeplinkHandler)
      .build()

  processor.match(uri, activity = this)

  After:

```kotlin
  val processor = DeeplinkProcessor.Builder()
      .register(OpenSeriesDeeplinkSpecs)
      .build()

  val params = processor.match(uri) as? AppDeeplinkParams ?: return
  when (params) {
      is OpenSeriesDeeplinkParams -> {
          // navigation/business logic
      }
  }
```