### PR TITLE
Fix query param order matching by moving typed query validation out of regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Query parameters are no longer part of `DeeplinkSpec`'s structural regex matcher.
+- `DeeplinkProcessor` now validates typed query params separately after structural URI matching.
+- `DeeplinkProcessor` URI normalization no longer includes query string content.
+
+### Fixed
+
+- Fixed critical query matching behavior where typed query params could fail when URL query order
+  differed from spec declaration order (for example, `?page=1&ref=promo` now matches
+  `ref + page` specs correctly).
+
+### Documentation
+
+- Updated README and docs pages to document order-agnostic typed query param matching semantics.
+- Updated release notes and migration guide with the query matching behavior change.
+
 ## [0.2.0-alpha] - 2026-02-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ deeplinkSpecs:
     fragment: "details"
 ```
 
+Typed query params are validated by key and type, so query ordering does not matter.
+For example, `?ref=promo&page=1` and `?page=1&ref=promo` are treated the same.
+
 5. Generate sources (or just build normally):
 
 ```bash

--- a/deepmatch-api/api/deepmatch-api.api
+++ b/deepmatch-api/api/deepmatch-api.api
@@ -21,6 +21,7 @@ public final class com/aouledissa/deepmatch/api/DeeplinkSpec {
 	public final fun getQueryParams ()Ljava/util/Set;
 	public final fun getScheme ()Ljava/util/Set;
 	public fun hashCode ()I
+	public final fun matchesQueryParams (Lkotlin/jvm/functions/Function1;)Z
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/deepmatch-processor/src/main/java/com/aouledissa/deepmatch/processor/DeeplinkProcessor.kt
+++ b/deepmatch-processor/src/main/java/com/aouledissa/deepmatch/processor/DeeplinkProcessor.kt
@@ -18,7 +18,9 @@ open class DeeplinkProcessor(
      * found.
      */
     open fun match(deeplink: Uri): DeeplinkParams? {
-        val spec = specs.find { it.matcher.matches(deeplink.decoded()) }
+        val spec = specs.find {
+            it.matcher.matches(deeplink.decoded()) && it.matchesQueryParams(deeplink::getQueryParameter)
+        }
             ?: return null
         return buildDeeplinkParams(spec, deeplink)
     }
@@ -26,9 +28,8 @@ open class DeeplinkProcessor(
     private fun Uri.decoded(): String {
         val decodedPathSegments = pathSegments.joinToString("/")
             .let { if (pathSegments.isNullOrEmpty().not()) "/$it" else it }
-        val decodedQuery = query?.let { "?$it" }.orEmpty()
         val decodedFragment = fragment?.let { "#$it" }.orEmpty()
-        return "$scheme://$host$decodedPathSegments$decodedQuery$decodedFragment"
+        return "$scheme://$host$decodedPathSegments$decodedFragment"
     }
 
     private fun buildDeeplinkParams(

--- a/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorRobolectricTest.kt
+++ b/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorRobolectricTest.kt
@@ -53,9 +53,40 @@ class DeeplinkProcessorRobolectricTest {
         assertThat(params).isNull()
     }
 
+    @Test
+    fun deeplinkWithOutOfOrderQueryParams_matchesAndReturnsParsedValues() {
+        val spec = DeeplinkSpec(
+            scheme = setOf("app"),
+            host = setOf("example.com"),
+            pathParams = linkedSetOf(
+                Param(name = "series"),
+                Param(name = "seriesId", type = ParamType.NUMERIC)
+            ),
+            queryParams = setOf(
+                Param(name = "ref", type = ParamType.STRING),
+                Param(name = "page", type = ParamType.NUMERIC)
+            ),
+            fragment = null,
+            parametersClass = PagedSeriesParams::class
+        )
+        val processor = DeeplinkProcessor(specs = setOf(spec))
+
+        val uri = Uri.parse("app://example.com/series/42?page=1&ref=promo")
+        val params = processor.match(uri) as PagedSeriesParams?
+        assertThat(params?.seriesId).isEqualTo(42)
+        assertThat(params?.page).isEqualTo(1)
+        assertThat(params?.ref).isEqualTo("promo")
+    }
+
     data class SeriesParams(
         val seriesId: Int,
         val ref: String?,
         val fragment: String?
+    ) : DeeplinkParams
+
+    data class PagedSeriesParams(
+        val seriesId: Int,
+        val ref: String?,
+        val page: Int?
     ) : DeeplinkParams
 }

--- a/docs/config_file.md
+++ b/docs/config_file.md
@@ -43,7 +43,8 @@ Each item in the `deeplinkSpecs` list is a deep link configuration object with t
 
 *   **`queryParams`**: (Optional, List of Param objects)
     *   Mirrors the structure of `pathParams` but for query string parameters.
-    *   Query params should declare a `type` so the generated regex and parameter class enforce the expected format and type conversion.
+    *   Query params should declare a `type` so runtime validation and generated parameter classes enforce the expected format and type conversion.
+    *   Query param matching is order-agnostic (`?page=1&ref=promo` and `?ref=promo&page=1` are equivalent).
     *   Example:
         ```yaml
         queryParams:
@@ -86,5 +87,6 @@ deeplinkSpecs:
 - Regenerate sources (`./gradlew generate<Variant>DeeplinkSpecs`) whenever you modify the YAML schema.
 - If `generateManifestFiles` is disabled, remember to replicate the `<intent-filter>` changes manually in your main manifest.
 - When a deeplink declares typed path, query, or fragment values, the plugin also creates a `<Name>DeeplinkParams` class so your app receives strongly typed arguments after calling `match(uri)`.
+- Typed query params are validated by key and type after structural URI matching, so query order does not affect matching.
 - All generated params classes implement a module-level sealed interface named from the module name (for example, module `app` -> `AppDeeplinkParams`), enabling exhaustive `when` checks.
 - The plugin also generates a module-level processor object named from the module name (for example, module `app` -> `AppDeeplinkProcessor`) preloaded with all generated specs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,9 @@ deeplinkSpecs:
         type: string
 ```
 
+Typed query params are validated by key and type, so query ordering does not matter.
+For example, `?ref=promo&page=1` and `?page=1&ref=promo` are treated the same.
+
 5. Generate sources (or run a normal build):
 
 ```bash


### PR DESCRIPTION
## Summary
  Typed query parameters were matched using a fixed-order regex, causing valid deeplinks to fail when query order differed from spec declaration (e.g. `?page=1&ref=promo` vs `?
  ref=promo&page=1`).

  This PR makes query matching order-agnostic by validating typed query params after structural URI matching.

  ## Changes
  - `deepmatch-api`
  - Removed query pattern from `DeeplinkSpec.buildMatcher()`
  - Added `DeeplinkSpec.matchesQueryParams(queryParamResolver: (String) -> String?)`
  - Updated API baseline (`deepmatch-api.api`)

  - `deepmatch-processor`
  - Updated matching flow to require:
    - structural regex match (`scheme + host + path + fragment`)
    - typed query validation via `matchesQueryParams(...)`
  - Updated URI normalization to exclude query string in regex input

  - Tests
  - Replaced query-regex assertions with `matchesQueryParams` behavior tests
  - Added integration test proving out-of-order query params match successfully

  - Docs/Changelog
  - Updated README and docs to state query matching is order-agnostic
  - Added Unreleased changelog section for this fix