### PR TITLE
Support optional query params by default with `required` flag, nullable codegen, and sample/docs updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,23 +14,32 @@
 - Fragment presence is now treated as a params-generation trigger in plugin config evaluation.
 - Fragment-only deeplink specs now generate `*DeeplinkParams` with a `fragment` property and wire
   `parametersClass` accordingly.
+- Added `required` to query params (`Param.required`) to support optional-vs-required query matching.
+- Optional typed query params are now generated as nullable constructor properties; required query
+  params remain non-null.
 
 ### Fixed
 
 - Fixed critical query matching behavior where typed query params could fail when URL query order
   differed from spec declaration order (for example, `?page=1&ref=promo` now matches
   `ref + page` specs correctly).
+- Fixed query matching strictness: typed query params are optional by default, validated only when
+  present, and enforced only when marked `required: true`.
 
 ### Documentation
 
 - Updated README and docs pages to document order-agnostic typed query param matching semantics.
 - Updated README/docs to clarify ordered path params list semantics in generated specs.
+- Updated docs to cover `queryParams.required` and generated nullability semantics for optional
+  query params.
 
 ### Tests
 
 - Added plugin tests to validate fragment-only specs generate params classes and that generated
   specs emit `pathParams = listOf(...)`.
 - Added processor regression coverage to ensure path matching remains positional and order-sensitive.
+- Added query optionality tests for API/processor/plugin generation, including required-missing
+  rejection and optional-missing acceptance.
 
 ## [0.2.0-alpha] - 2026-02-25
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ deeplinkSpecs:
       - name: seriesId
         type: numeric
     queryParams:
+      - name: query
+        type: string
+        required: true
       - name: ref
         type: string
     fragment: "details"
@@ -87,6 +90,7 @@ deeplinkSpecs:
 
 Typed query params are validated by key and type, so query ordering does not matter.
 For example, `?ref=promo&page=1` and `?page=1&ref=promo` are treated the same.
+Query params are optional by default; use `required: true` for mandatory keys.
 Path params are ordered and matched by position as declared in YAML.
 Declaring a `fragment` also triggers params-class generation and exposes `fragment` in the generated
 `*DeeplinkParams` type, even when no typed path/query params are present.

--- a/deepmatch-api/api/deepmatch-api.api
+++ b/deepmatch-api/api/deepmatch-api.api
@@ -42,14 +42,16 @@ public final class com/aouledissa/deepmatch/api/DeeplinkSpec$Companion {
 
 public final class com/aouledissa/deepmatch/api/Param {
 	public static final field Companion Lcom/aouledissa/deepmatch/api/Param$Companion;
-	public fun <init> (Ljava/lang/String;Lcom/aouledissa/deepmatch/api/ParamType;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/aouledissa/deepmatch/api/ParamType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/aouledissa/deepmatch/api/ParamType;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/aouledissa/deepmatch/api/ParamType;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/aouledissa/deepmatch/api/ParamType;
-	public final fun copy (Ljava/lang/String;Lcom/aouledissa/deepmatch/api/ParamType;)Lcom/aouledissa/deepmatch/api/Param;
-	public static synthetic fun copy$default (Lcom/aouledissa/deepmatch/api/Param;Ljava/lang/String;Lcom/aouledissa/deepmatch/api/ParamType;ILjava/lang/Object;)Lcom/aouledissa/deepmatch/api/Param;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Lcom/aouledissa/deepmatch/api/ParamType;Z)Lcom/aouledissa/deepmatch/api/Param;
+	public static synthetic fun copy$default (Lcom/aouledissa/deepmatch/api/Param;Ljava/lang/String;Lcom/aouledissa/deepmatch/api/ParamType;ZILjava/lang/Object;)Lcom/aouledissa/deepmatch/api/Param;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
+	public final fun getRequired ()Z
 	public final fun getType ()Lcom/aouledissa/deepmatch/api/ParamType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/deepmatch-api/src/main/java/com/aouledissa/deepmatch/api/DeeplinkSpec.kt
+++ b/deepmatch-api/src/main/java/com/aouledissa/deepmatch/api/DeeplinkSpec.kt
@@ -25,7 +25,11 @@ data class DeeplinkSpec(
         if (queryParams.isEmpty()) return true
         return queryParams.filter { it.type != null }.all { param ->
             val value = queryParamResolver(param.name)
-            value != null && param.type!!.regex.matches(value)
+            when {
+                value != null && param.type != null -> param.type.regex.matches(value)
+                param.required -> false
+                else -> true
+            }
         }
     }
 
@@ -78,7 +82,8 @@ private val stringRegex = "[a-zA-Z._~-]+".toRegex()
 @Serializable
 data class Param(
     val name: String,
-    val type: ParamType? = null
+    val type: ParamType? = null,
+    val required: Boolean = false
 ) {
     override fun toString(): String {
         return "Param(name = \"$name\", type = ${
@@ -86,7 +91,7 @@ data class Param(
                 null -> null
                 else -> "${ParamType::class.simpleName}.${type.name}"
             }
-        })"
+        }, required = $required)"
     }
 }
 

--- a/deepmatch-api/src/test/java/com/aouledissa/deepmatch/api/DeeplinkSpecTest.kt
+++ b/deepmatch-api/src/test/java/com/aouledissa/deepmatch/api/DeeplinkSpecTest.kt
@@ -160,22 +160,35 @@ class DeeplinkSpecTest {
     }
 
     @Test
+    fun `matchesQueryParams returns true when optional typed query param is missing`() {
+        // when
+        sut = DeeplinkSpec(
+            scheme = setOf("https"),
+            host = setOf("test.com"),
+            pathParams = emptyList(),
+            queryParams = setOf(Param(name = "page", type = ParamType.NUMERIC)),
+            fragment = null,
+            parametersClass = null
+        )
+
+        // then
+        assertThat(sut.matchesQueryParams(queryParamResolver(""))).isTrue()
+    }
+
+    @Test
     fun `matchesQueryParams returns false when required typed query param is missing`() {
         // when
         sut = DeeplinkSpec(
             scheme = setOf("https"),
             host = setOf("test.com"),
             pathParams = emptyList(),
-            queryParams = setOf(
-                Param(name = "ref", type = ParamType.STRING),
-                Param(name = "page", type = ParamType.NUMERIC)
-            ),
+            queryParams = setOf(Param(name = "page", type = ParamType.NUMERIC, required = true)),
             fragment = null,
             parametersClass = null
         )
 
         // then
-        assertThat(sut.matchesQueryParams(queryParamResolver("ref=promo"))).isFalse()
+        assertThat(sut.matchesQueryParams(queryParamResolver(""))).isFalse()
     }
 
     @Test

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkSpecsTask.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkSpecsTask.kt
@@ -19,6 +19,7 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asTypeName
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
@@ -255,7 +256,7 @@ internal abstract class GenerateDeeplinkSpecsTask : DefaultTask() {
                 add(
                     ParameterSpec.builder(
                         it.name.toCamelCase(),
-                        it.type!!.getType()
+                        it.type!!.getType().asTypeName().copy(nullable = !it.required)
                     ).build()
                 )
             }

--- a/docs/gradle_plugin.md
+++ b/docs/gradle_plugin.md
@@ -65,6 +65,7 @@ During the build the plugin generates Kotlin sources under `build/generated/` an
 - `*DeeplinkSpecs.kt` — exposes a `DeeplinkSpec` property per configuration entry.
   Generated specs use `pathParams` as an ordered list to preserve YAML-declared path segment order.
 - `*DeeplinkParams.kt` — optional data class emitted when a deeplink defines typed template/query params or a fragment requirement (including fragment-only specs).
+  Query params marked `required: true` are generated as non-null properties; optional query params are generated as nullable properties.
 - Generated manifest file — contains `<intent-filter>` definitions that Gradle merges into the final manifest.
 
 ### Available Tasks

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,12 +53,16 @@ deeplinkSpecs:
       - name: seriesId
         type: numeric
     queryParams:
+      - name: query
+        type: string
+        required: true
       - name: ref
         type: string
 ```
 
 Typed query params are validated by key and type, so query ordering does not matter.
 For example, `?ref=promo&page=1` and `?page=1&ref=promo` are treated the same.
+Query params are optional by default; use `required: true` for mandatory keys.
 Path params are ordered and matched by position as declared in YAML.
 
 5. Generate sources (or run a normal build):

--- a/samples/android-app/.deeplinks.yml
+++ b/samples/android-app/.deeplinks.yml
@@ -11,6 +11,7 @@ deeplinkSpecs:
     queryParams:
       - name: ref
         type: string
+        required: true
     fragment: "details"
 
   - name: "open series"

--- a/samples/android-app/README.md
+++ b/samples/android-app/README.md
@@ -41,6 +41,11 @@ adb shell am start -W \
 
 The screen should render parsed output for `OpenSeriesDeeplinkParams` and `OpenProfileDeeplinkParams`.
 
+In this sample:
+- `open series` keeps `ref` optional.
+- `open profile` sets `ref` as required (`required: true`) in `.deeplinks.yml`, so profile links
+  must include `?ref=...` to match.
+
 ## Notes
 
 - The sample uses composite build (`includeBuild("../..")`) to consume the local plugin and modules.

--- a/samples/android-app/src/main/java/com/aouledissa/deepmatch/sample/MainActivity.kt
+++ b/samples/android-app/src/main/java/com/aouledissa/deepmatch/sample/MainActivity.kt
@@ -47,7 +47,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val uri = intent.data ?: "app://sample.deepmatch.dev/series/42?ref=home".toUri()
+        val uri = intent.data ?: "app://sample.deepmatch.dev/series/42".toUri()
 
         setContent {
             DeeplinkResultScreen(uri = uri)
@@ -67,7 +67,7 @@ private fun DeeplinkResultScreen(uri: Uri) {
             accent = Color(0xFF0E7C66),
             properties = listOf(
                 "userId" to result.userId,
-                "ref" to result.ref,
+                "ref" to (result.ref ?: "absent"),
                 "fragment" to result.fragment
             )
         )
@@ -78,7 +78,7 @@ private fun DeeplinkResultScreen(uri: Uri) {
             accent = Color(0xFF1F6FEB),
             properties = listOf(
                 "seriesId" to result.seriesId.toString(),
-                "ref" to result.ref
+                "ref" to (result.ref ?: "absent")
             )
         )
 
@@ -279,7 +279,7 @@ private enum class DemoUri(
 ) {
     Profile(
         label = "Profile",
-        uri = "app://sample.deepmatch.dev/profile/john123?ref=campaign#details"
+        uri = "app://sample.deepmatch.dev/profile/john123#details"
     ),
     Series(label = "Series", uri = "app://sample.deepmatch.dev/series/42?ref=home"),
     NoMatch(label = "No Match", uri = "app://sample.deepmatch.dev/unknown");


### PR DESCRIPTION
## Summary
  This PR adds first-class query param optionality to DeepMatch.

  Typed query params are now optional by default. A new `required` flag controls whether a query key must be present for a match:
  - `required: true` => missing key fails match
  - omitted / `false` => missing key is allowed, value is validated only when present

  ## What changed
  - API
  - Added `required: Boolean = false` to `Param`
  - Updated query matching logic to enforce presence only for required params

  - Plugin codegen
  - Optional typed query params are generated as nullable constructor properties
  - Required typed query params remain non-null

  - Runtime/tests
  - Added coverage for:
    - optional query param missing => match succeeds
    - required query param missing => no match
    - type validation still enforced when value is present

  - Sample
  - Updated sample `.deeplinks.yml` to include at least one `required: true` query param example
  - Updated sample UI and README to reflect optional/required behavior

  - Docs/changelog
  - Updated README + docs (`config_file`, `index`, `gradle_plugin`) for `queryParams.required`
  - Updated `CHANGELOG.md` under `Unreleased`