### PR TITLE
Always generate params classes for static deeplinks to disambiguate match results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@
   segment order is preserved explicitly.
 - Plugin code generation now emits `pathParams = listOf(...)` for generated specs to align with
   the new API shape.
-- Fragment presence is now treated as a params-generation trigger in plugin config evaluation.
-- Fragment-only deeplink specs now generate `*DeeplinkParams` with a `fragment` property and wire
-  `parametersClass` accordingly.
+- Fragment-only deeplink specs generate `*DeeplinkParams` with a `fragment` property and wire
+  `parametersClass` accordingly (alongside the new always-generate params behavior).
 - Added `required` to query params (`Param.required`) to support optional-vs-required query matching.
 - Optional typed query params are now generated as nullable constructor properties; required query
   params remain non-null.
+- Plugin code generation now emits a `*DeeplinkParams` class for every deeplink spec, including
+  static-only specs with no typed path/query/fragment fields.
 
 ### Fixed
 
@@ -25,6 +26,8 @@
   `ref + page` specs correctly).
 - Fixed query matching strictness: typed query params are optional by default, validated only when
   present, and enforced only when marked `required: true`.
+- Fixed match-result ambiguity for generated processors: static deeplink matches no longer collapse
+  to `null` (which was previously indistinguishable from "no match").
 
 ### Documentation
 
@@ -40,6 +43,8 @@
 - Added processor regression coverage to ensure path matching remains positional and order-sensitive.
 - Added query optionality tests for API/processor/plugin generation, including required-missing
   rejection and optional-missing acceptance.
+- Added regression tests ensuring static-only specs generate params classes and return a concrete
+  params instance on successful match.
 
 ## [0.2.0-alpha] - 2026-02-25
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ DeepMatch is an Android deep-linking toolkit that turns a `.deeplinks.yml` file 
 code, optional manifest entries, and runtime routing logic. Point the plugin at your configuration
 and it will:
 
-- Generate strongly-typed deeplink specs (plus parameter classes when the link declares template,
-  query, or fragment values).
+- Generate strongly-typed deeplink specs and one parameter class per deeplink spec.
 - Generate a module-level sealed params interface (for example, module `app` generates
   `AppDeeplinkParams`) that all generated params classes implement.
 - Optionally emit manifest snippets so you never hand-write `<intent-filter>` entries again.
@@ -92,8 +91,8 @@ Typed query params are validated by key and type, so query ordering does not mat
 For example, `?ref=promo&page=1` and `?page=1&ref=promo` are treated the same.
 Query params are optional by default; use `required: true` for mandatory keys.
 Path params are ordered and matched by position as declared in YAML.
-Declaring a `fragment` also triggers params-class generation and exposes `fragment` in the generated
-`*DeeplinkParams` type, even when no typed path/query params are present.
+Each deeplink spec always generates a `*DeeplinkParams` type, so a successful match is never
+ambiguous with "no match". When declared, `fragment` is exposed in the generated params type.
 
 5. Generate sources (or just build normally):
 
@@ -104,7 +103,7 @@ Declaring a `fragment` also triggers params-class generation and exposes `fragme
 DeepMatch generates:
 - `<ModuleName>DeeplinkProcessor` (example: `AppDeeplinkProcessor`)
 - `<ModuleName>DeeplinkParams` sealed interface (example: `AppDeeplinkParams`)
-- `*DeeplinkSpecs` and typed `*DeeplinkParams` classes
+- `*DeeplinkSpecs` and `*DeeplinkParams` classes
 
 6. Use the generated processor at runtime:
 

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/model/Specs.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/model/Specs.kt
@@ -21,9 +21,7 @@ internal data class DeeplinkConfig(
     val fragment: String? = null
 ) {
 
-    fun containsTemplateParams(): Boolean {
-        return pathParams?.any { it.type != null } == true
-                || queryParams.isNullOrEmpty().not()
-                || fragment != null
-    }
+    fun hasTypedParams(): Boolean =
+        pathParams?.any { it.type != null } == true ||
+                queryParams?.any { it.type != null } == true
 }

--- a/deepmatch-plugin/src/test/java/com/aouledissa/deepmatch/gradle/internal/model/DeeplinkConfigTest.kt
+++ b/deepmatch-plugin/src/test/java/com/aouledissa/deepmatch/gradle/internal/model/DeeplinkConfigTest.kt
@@ -1,25 +1,27 @@
 package com.aouledissa.deepmatch.gradle.internal.model
 
+import com.aouledissa.deepmatch.api.Param
+import com.aouledissa.deepmatch.api.ParamType
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class DeeplinkConfigTest {
 
     @Test
-    fun `containsTemplateParams returns true when fragment is present`() {
+    fun `hasTypedParams returns true when typed path param is present`() {
         val config = DeeplinkConfig(
             name = "open profile",
             activity = "com.example.app.MainActivity",
             scheme = listOf("app"),
             host = listOf("example.com"),
-            fragment = "details"
+            pathParams = listOf(Param(name = "id", type = ParamType.NUMERIC))
         )
 
-        assertThat(config.containsTemplateParams()).isTrue()
+        assertThat(config.hasTypedParams()).isTrue()
     }
 
     @Test
-    fun `containsTemplateParams returns false when no typed inputs are defined`() {
+    fun `hasTypedParams returns false when no typed inputs are defined`() {
         val config = DeeplinkConfig(
             name = "open profile",
             activity = "com.example.app.MainActivity",
@@ -28,6 +30,6 @@ class DeeplinkConfigTest {
             fragment = null
         )
 
-        assertThat(config.containsTemplateParams()).isFalse()
+        assertThat(config.hasTypedParams()).isFalse()
     }
 }

--- a/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorRobolectricTest.kt
+++ b/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorRobolectricTest.kt
@@ -139,6 +139,22 @@ class DeeplinkProcessorRobolectricTest {
         assertThat(params).isNull()
     }
 
+    @Test
+    fun staticDeeplinkMatch_returnsEmptyParamsInstance() {
+        val spec = DeeplinkSpec(
+            scheme = setOf("app"),
+            host = setOf("example.com"),
+            pathParams = listOf(Param(name = "home")),
+            queryParams = emptySet(),
+            fragment = null,
+            parametersClass = HomeParams::class
+        )
+        val processor = DeeplinkProcessor(specs = setOf(spec))
+
+        val params = processor.match(Uri.parse("app://example.com/home"))
+        assertThat(params).isInstanceOf(HomeParams::class.java)
+    }
+
     data class SeriesParams(
         val seriesId: Int,
         val ref: String?,
@@ -164,4 +180,6 @@ class DeeplinkProcessorRobolectricTest {
         val seriesId: Int,
         val ref: String
     ) : DeeplinkParams
+
+    class HomeParams : DeeplinkParams
 }

--- a/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorTest.kt
+++ b/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorTest.kt
@@ -97,9 +97,36 @@ class DeeplinkProcessorTest {
         assertThat(params).isNull()
     }
 
+    @Test
+    fun `match returns params instance for static spec with empty params class`() {
+        val spec = DeeplinkSpec(
+            scheme = setOf("app"),
+            host = setOf("example.com"),
+            pathParams = listOf(Param(name = "home")),
+            queryParams = emptySet(),
+            fragment = null,
+            parametersClass = HomeParams::class
+        )
+
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.scheme } returns "app"
+        every { uri.host } returns "example.com"
+        every { uri.pathSegments } returns listOf("home")
+        every { uri.query } returns null
+        every { uri.fragment } returns null
+        every { uri.getQueryParameter(any()) } returns null
+
+        val processor = DeeplinkProcessor(specs = setOf(spec))
+
+        val params = processor.match(uri)
+        assertThat(params).isInstanceOf(HomeParams::class.java)
+    }
+
     data class SeriesParams(
         val seriesId: Int,
         val ref: String?,
         val fragment: String?
     ) : DeeplinkParams
+
+    class HomeParams : DeeplinkParams
 }

--- a/docs/deeplink-specs.md
+++ b/docs/deeplink-specs.md
@@ -178,7 +178,7 @@ deeplinkSpecs:
 - Keep `name` values unique per spec to simplify generated type naming and runtime routing.
 - Regenerate sources (`./gradlew generate<Variant>DeeplinkSpecs`) whenever you modify the YAML schema.
 - If `generateManifestFiles` is disabled, remember to replicate the `<intent-filter>` changes manually in your main manifest.
-- When a deeplink declares typed path, query, or fragment values, the plugin also creates a `<Name>DeeplinkParams` class so your app receives strongly typed arguments after calling `match(uri)`.
+- The plugin creates a `<Name>DeeplinkParams` class for every deeplink spec. This avoids ambiguity between "no match" and "matched static deeplink".
 - Typed query params are validated by key and type after structural URI matching, so query order does not affect matching.
 - Query params are optional by default; set `required: true` only for values that must be present.
 - All generated params classes implement a module-level sealed interface named from the module name (for example, module `app` -> `AppDeeplinkParams`), enabling exhaustive `when` checks.

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -14,7 +14,7 @@ The primary responsibilities and capabilities of the DeepMatch Gradle plugin are
 
 3.  **Code Generation (`DeeplinkSpecs`):**
     *   The plugin generates Kotlin source code, most notably a class named something like `[DeeplinkName]DeeplinkSpecs` (the exact name might vary based on the deeplink name in the `.yml` file).
-    *   The plugin also generates params classes for deeplinks with typed path/query/fragment values.
+    *   The plugin also generates a params class for every deeplink spec, including static-only specs.
     *   It additionally generates a module-level sealed interface (for example, module `app` -> `AppDeeplinkParams`) implemented by all generated params classes, enabling exhaustive `when` matching in app code.
     *   It generates a module-level processor object (for example, module `app` -> `AppDeeplinkProcessor`) wired with all generated specs so no manual registration is required.
 
@@ -64,7 +64,7 @@ During the build the plugin generates Kotlin sources under `build/generated/` an
 - `<ModuleName>DeeplinkProcessor.kt` — module-level processor object extending `DeeplinkProcessor` and preconfigured with all generated specs.
 - `*DeeplinkSpecs.kt` — exposes a `DeeplinkSpec` property per configuration entry.
   Generated specs use `pathParams` as an ordered list to preserve YAML-declared path segment order.
-- `*DeeplinkParams.kt` — optional data class emitted when a deeplink defines typed template/query params or a fragment requirement (including fragment-only specs).
+- `*DeeplinkParams.kt` — params class emitted for every deeplink spec. When a spec has typed values, generated constructor properties are strongly typed.
   Query params marked `required: true` are generated as non-null properties; optional query params are generated as nullable properties.
 - Generated manifest file — contains `<intent-filter>` definitions that Gradle merges into the final manifest.
 


### PR DESCRIPTION
## Summary

  This PR removes the ambiguity where DeeplinkProcessor.match() could return null for both:

  - no matched spec
  - matched static-only spec with parametersClass = null

  The plugin now always generates a *DeeplinkParams class for each spec (including static-only specs), and always wires parametersClass in generated DeeplinkSpec.

  ## What changed

  - Updated codegen to always emit *DeeplinkParams per deeplink spec.
  - Updated generated class behavior:
      - specs with constructor fields -> generated as data class
      - specs with no fields -> generated as plain class with empty constructor
  - Updated plugin model helper:
      - replaced containsTemplateParams() with hasTypedParams() for typed-import logic only.
  - Ensured generated spec always sets parametersClass = <GeneratedParams>::class.

 ## Outcome

  Successful static deeplink matches are now distinguishable from “no match” in generated flows, enabling clearer exhaustive handling in client when branches.
