### PR TITLE
Add hostless deeplink support (optional host + scheme validation) and sample coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   params remain non-null.
 - Plugin code generation now emits a `*DeeplinkParams` class for every deeplink spec, including
   static-only specs with no typed path/query/fragment fields.
+- Plugin config model now treats `host` as optional (`[]` by default), enabling hostless specs.
 
 ### Fixed
 
@@ -28,6 +29,8 @@
   present, and enforced only when marked `required: true`.
 - Fixed match-result ambiguity for generated processors: static deeplink matches no longer collapse
   to `null` (which was previously indistinguishable from "no match").
+- Fixed hostless deeplink matching (`app:///...`) by explicitly supporting empty-host specs.
+- Added build-time validation that every spec declares at least one scheme.
 
 ### Documentation
 
@@ -47,6 +50,7 @@
   params instance on successful match.
 - Added processor coverage for case-insensitive scheme/host matching (for example,
   `HTTPS://Example.COM/...` and `App://EXAMPLE.com/...`).
+- Added coverage for hostless deeplinks, including regex match, params extraction, and manifest output without `android:host`.
 
 ## [0.2.0-alpha] - 2026-02-25
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ For example, `?ref=promo&page=1` and `?page=1&ref=promo` are treated the same.
 Query params are optional by default; use `required: true` for mandatory keys.
 Scheme and host matching are case-insensitive (for example, `HTTPS://Example.COM/...` matches
 `scheme: [https]` + `host: ["example.com"]`).
+Host is optional; omit it (or set `host: []`) for hostless URIs such as `app:///profile/123`.
 Path params are ordered and matched by position as declared in YAML.
 Each deeplink spec always generates a `*DeeplinkParams` type, so a successful match is never
 ambiguous with "no match". When declared, `fragment` is exposed in the generated params type.

--- a/deepmatch-api/src/main/java/com/aouledissa/deepmatch/api/DeeplinkSpec.kt
+++ b/deepmatch-api/src/main/java/com/aouledissa/deepmatch/api/DeeplinkSpec.kt
@@ -48,6 +48,7 @@ data class DeeplinkSpec(
     }
 
     private fun buildHostPattern(): String {
+        if (host.isEmpty()) return ""
         return host.joinToString(separator = "|") { Regex.escape(it) }
             .let { if (host.size > 1) "($it)" else it }
     }

--- a/deepmatch-api/src/test/java/com/aouledissa/deepmatch/api/DeeplinkSpecTest.kt
+++ b/deepmatch-api/src/test/java/com/aouledissa/deepmatch/api/DeeplinkSpecTest.kt
@@ -140,6 +140,23 @@ class DeeplinkSpecTest {
     }
 
     @Test
+    fun `deeplink matcher supports empty host`() {
+        sut = DeeplinkSpec(
+            scheme = setOf("app"),
+            host = emptySet(),
+            pathParams = listOf(
+                Param(name = "profile"),
+                Param(name = "profileId", type = ParamType.NUMERIC)
+            ),
+            queryParams = emptySet(),
+            fragment = null,
+            parametersClass = null
+        )
+
+        assertThat(sut.matcher.matches("app:///profile/123")).isTrue()
+    }
+
+    @Test
     fun `matchesQueryParams returns true regardless of query params order`() {
         // when
         sut = DeeplinkSpec(

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/model/Specs.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/model/Specs.kt
@@ -15,7 +15,7 @@ internal data class DeeplinkConfig(
     val categories: List<IntentFilterCategory> = listOf(IntentFilterCategory.DEFAULT),
     val autoVerify: Boolean = false,
     val scheme: List<String>,
-    val host: List<String>,
+    val host: List<String> = emptyList(),
     val pathParams: List<Param>? = null,
     val queryParams: List<Param>? = null,
     val fragment: String? = null

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkSpecsTask.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkSpecsTask.kt
@@ -67,6 +67,7 @@ internal abstract class GenerateDeeplinkSpecsTask : DefaultTask() {
             .writeTo(outputFile)
 
         deeplinkConfigs.forEach { config ->
+            assertRequiredFields(config)
             assertValidQueryParams(config)
             val deeplinkName = config.name.toCamelCase().plus("Deeplink")
             val fileName = deeplinkName.plus("Specs").capitalize()
@@ -167,7 +168,6 @@ internal abstract class GenerateDeeplinkSpecsTask : DefaultTask() {
             DeeplinkSpec::class.java.simpleName
         )
         val schemes = config.scheme.joinToString(separator = ", ") { "\"$it\"" }
-        // TODO: is empty host case handled?
         val hosts = config.host.joinToString(separator = ", ") { "\"$it\"" }
         val pathParams = config.pathParams?.joinToString(separator = ", ").orEmpty()
         val queryParams = config.queryParams?.joinToString(separator = ", ").orEmpty()
@@ -296,6 +296,14 @@ internal abstract class GenerateDeeplinkSpecsTask : DefaultTask() {
             if (queryParams.all { it.type != null }.not()) {
                 throw GradleException("DeepMatch: All queryParams should define a type: [numeric, alphanumeric, string]")
             }
+        }
+    }
+
+    private fun assertRequiredFields(config: DeeplinkConfig) {
+        if (config.scheme.isEmpty()) {
+            throw GradleException(
+                "DeepMatch: Spec '${config.name}' must define at least one scheme."
+            )
         }
     }
 }

--- a/deepmatch-plugin/src/test/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkManifestFileTest.kt
+++ b/deepmatch-plugin/src/test/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkManifestFileTest.kt
@@ -1,0 +1,43 @@
+package com.aouledissa.deepmatch.gradle.internal.task
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class GenerateDeeplinkManifestFileTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `hostless spec does not generate android host attribute`() {
+        val project = ProjectBuilder.builder().build()
+        val specsFile = temporaryFolder.newFile("hostless-manifest.deeplinks.yml").apply {
+            writeText(
+                """
+                deeplinkSpecs:
+                  - name: "open profile"
+                    activity: com.example.app.MainActivity
+                    scheme: [app]
+                    pathParams:
+                      - name: profile
+                      - name: profileId
+                        type: numeric
+                """.trimIndent()
+            )
+        }
+        val outputManifest = temporaryFolder.newFile("AndroidManifest.xml")
+        val task = project.tasks.register("generateManifest", GenerateDeeplinkManifestFile::class.java).get()
+
+        task.specFileProperty.set(project.layout.file(project.provider { specsFile }))
+        task.outputFile.set(project.layout.file(project.provider { outputManifest }))
+
+        task.generateDeeplinkManifest()
+
+        val xml = outputManifest.readText()
+        assertThat(xml).contains("android:scheme=\"app\"")
+        assertThat(xml).doesNotContain("android:host=")
+    }
+}

--- a/deepmatch-processor/src/main/java/com/aouledissa/deepmatch/processor/DeeplinkProcessor.kt
+++ b/deepmatch-processor/src/main/java/com/aouledissa/deepmatch/processor/DeeplinkProcessor.kt
@@ -30,7 +30,7 @@ open class DeeplinkProcessor(
             .trimEnd('/')
             .let { if (pathSegments.isNullOrEmpty().not()) "/$it" else it }
         val decodedFragment = fragment?.let { "#$it" }.orEmpty()
-        return "$scheme://$host$decodedPathSegments$decodedFragment"
+        return "$scheme://${host.orEmpty()}$decodedPathSegments$decodedFragment"
     }
 
     private fun buildDeeplinkParams(

--- a/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorRobolectricTest.kt
+++ b/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorRobolectricTest.kt
@@ -234,6 +234,25 @@ class DeeplinkProcessorRobolectricTest {
         assertThat(withTrailingSlash?.userId).isEqualTo(123)
     }
 
+    @Test
+    fun hostlessDeeplink_matchesAndExtractsPathParams() {
+        val spec = DeeplinkSpec(
+            scheme = setOf("app"),
+            host = emptySet(),
+            pathParams = listOf(
+                Param(name = "profile"),
+                Param(name = "profileId", type = ParamType.NUMERIC)
+            ),
+            queryParams = emptySet(),
+            fragment = null,
+            parametersClass = HostlessProfileParams::class
+        )
+        val processor = DeeplinkProcessor(specs = setOf(spec))
+
+        val params = processor.match(Uri.parse("app:///profile/123")) as HostlessProfileParams?
+        assertThat(params?.profileId).isEqualTo(123)
+    }
+
     data class SeriesParams(
         val seriesId: Int,
         val ref: String?,
@@ -268,5 +287,9 @@ class DeeplinkProcessorRobolectricTest {
 
     data class NumericProfileParams(
         val userId: Int
+    ) : DeeplinkParams
+
+    data class HostlessProfileParams(
+        val profileId: Int
     ) : DeeplinkParams
 }

--- a/docs/deeplink-specs.md
+++ b/docs/deeplink-specs.md
@@ -49,8 +49,8 @@ Each item in the deeplinkSpecs list is a deep link configuration object with the
 
 - `host`
     - Type: List<String>
-    - Required: Yes
-    - Description: Allowed URI hosts/domains.
+    - Required: No (default: [])
+    - Description: Allowed URI hosts/domains. Leave empty (or omit) for hostless URIs such as app:///profile/123.
     - Example:
       ```yaml
       host: ["example.com", "m.example.com"]
@@ -182,5 +182,6 @@ deeplinkSpecs:
 - Typed query params are validated by key and type after structural URI matching, so query order does not affect matching.
 - Query params are optional by default; set `required: true` only for values that must be present.
 - Scheme and host matching are case-insensitive, so values like `HTTPS://Example.COM/...` still match `scheme: [https]` and `host: ["example.com"]`.
+- `scheme` must contain at least one value. `host` can be omitted (or set to `[]`) for hostless URIs.
 - All generated params classes implement a module-level sealed interface named from the module name (for example, module `app` -> `AppDeeplinkParams`), enabling exhaustive `when` checks.
 - The plugin also generates a module-level processor object named from the module name (for example, module `app` -> `AppDeeplinkProcessor`) preloaded with all generated specs.

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -7,6 +7,7 @@ The primary responsibilities and capabilities of the DeepMatch Gradle plugin are
         *   `src/<variant>/.deeplinks.yml` (variant-specific)
         *   `.deeplinks.yml` at the module root (fallback)
     *   It parses the YAML content, validating its structure against the expected format (implicitly defined by how it generates code and manifest entries, aligning with the `DeeplinkConfig` structure).
+    *   Each spec must define at least one `scheme`; `host` is optional and can be omitted for hostless deeplinks.
 
 2.  **Android Manifest Generation:**
     *   Based on the parsed `deeplinkSpecs` from your YAML file, the plugin dynamically generates the necessary `<intent-filter>` entries within your app's `AndroidManifest.xml`.

--- a/samples/android-app/.deeplinks.yml
+++ b/samples/android-app/.deeplinks.yml
@@ -26,3 +26,12 @@ deeplinkSpecs:
     queryParams:
       - name: ref
         type: string
+
+  - name: "open hostless profile"
+    activity: com.aouledissa.deepmatch.sample.MainActivity
+    categories: [DEFAULT, BROWSABLE]
+    scheme: [app]
+    pathParams:
+      - name: profile
+      - name: profileId
+        type: numeric

--- a/samples/android-app/README.md
+++ b/samples/android-app/README.md
@@ -39,12 +39,21 @@ adb shell am start -W \
   -d "app://sample.deepmatch.dev/profile/john123?ref=campaign#details"
 ```
 
-The screen should render parsed output for `OpenSeriesDeeplinkParams` and `OpenProfileDeeplinkParams`.
+```bash
+adb shell am start -W \
+  -a android.intent.action.VIEW \
+  -c android.intent.category.BROWSABLE \
+  -d "app:///profile/123"
+```
+
+The screen should render parsed output for `OpenSeriesDeeplinkParams`, `OpenProfileDeeplinkParams`,
+and `OpenHostlessProfileDeeplinkParams`.
 
 In this sample:
 - `open series` keeps `ref` optional.
 - `open profile` sets `ref` as required (`required: true`) in `.deeplinks.yml`, so profile links
   must include `?ref=...` to match.
+- `open hostless profile` demonstrates a hostless URI (`app:///...`) with typed path extraction.
 
 ## Notes
 

--- a/samples/android-app/src/main/java/com/aouledissa/deepmatch/sample/MainActivity.kt
+++ b/samples/android-app/src/main/java/com/aouledissa/deepmatch/sample/MainActivity.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -40,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import com.aouledissa.deepmatch.sample.deeplinks.AppDeeplinkParams
 import com.aouledissa.deepmatch.sample.deeplinks.AppDeeplinkProcessor
+import com.aouledissa.deepmatch.sample.deeplinks.OpenHostlessProfileDeeplinkParams
 import com.aouledissa.deepmatch.sample.deeplinks.OpenProfileDeeplinkParams
 import com.aouledissa.deepmatch.sample.deeplinks.OpenSeriesDeeplinkParams
 
@@ -56,6 +59,7 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
+@OptIn(ExperimentalLayoutApi::class)
 private fun DeeplinkResultScreen(uri: Uri) {
     var selectedDemo by rememberSaveable { mutableStateOf(detectDemoUri(uri)) }
     val selectedUri = selectedDemo.uri.toUri()
@@ -79,6 +83,15 @@ private fun DeeplinkResultScreen(uri: Uri) {
             properties = listOf(
                 "seriesId" to result.seriesId.toString(),
                 "ref" to (result.ref ?: "absent")
+            )
+        )
+
+        is OpenHostlessProfileDeeplinkParams -> MatchUi(
+            title = "Hostless Deeplink",
+            subtitle = "Matched hostless URI (no host) successfully",
+            accent = Color(0xFF7C3AED),
+            properties = listOf(
+                "profileId" to result.profileId.toString()
             )
         )
 
@@ -127,9 +140,10 @@ private fun DeeplinkResultScreen(uri: Uri) {
                             style = MaterialTheme.typography.labelLarge,
                             fontWeight = FontWeight.SemiBold
                         )
-                        Row(
+                        FlowRow(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             DemoUri.entries.forEach { demo ->
                                 UriOptionButton(
@@ -281,6 +295,7 @@ private enum class DemoUri(
         label = "Profile",
         uri = "app://sample.deepmatch.dev/profile/john123?ref=demo#details"
     ),
+    Hostless(label = "Hostless", uri = "app:///profile/123"),
     Series(label = "Series", uri = "app://sample.deepmatch.dev/series/42?ref=home"),
     NoMatch(label = "No Match", uri = "app://sample.deepmatch.dev/unknown");
 }
@@ -288,6 +303,7 @@ private enum class DemoUri(
 private fun detectDemoUri(uri: Uri): DemoUri {
     return when (val params = AppDeeplinkProcessor.match(uri) as? AppDeeplinkParams) {
         is OpenProfileDeeplinkParams -> DemoUri.Profile
+        is OpenHostlessProfileDeeplinkParams -> DemoUri.Hostless
         is OpenSeriesDeeplinkParams -> DemoUri.Series
         null -> DemoUri.NoMatch
     }


### PR DESCRIPTION
## Summary

  This PR adds first-class support for hostless deeplinks (e.g. app:///profile/123), enforces non-empty schemes at build time, and updates the sample app/docs/tests accordingly.

  ## What changed

  ### Runtime/API

  - DeeplinkSpec now handles empty host explicitly in matcher construction.
  - DeeplinkProcessor host normalization now uses host.orEmpty() so hostless URIs decode consistently.

  ### Plugin/model

  - DeeplinkConfig.host is now optional with default emptyList().
  - Added required-field validation in GenerateDeeplinkSpecsTask:
      - throws GradleException if scheme is empty.
  - Removed stale TODO around empty host handling.

  ### Tests

  - Added API matcher coverage for hostless URI matching.
  - Added processor Robolectric test for hostless URI param extraction.
  - Added plugin codegen tests for:
      - host: [] generation
      - omitted host generation
      - empty scheme validation failure
  - Added plugin manifest test ensuring hostless specs do not generate android:host.

  ### Sample app

  - Added hostless spec to samples/android-app/.deeplinks.yml.
  - Added hostless demo route handling in Compose UI (OpenHostlessProfileDeeplinkParams).
  - Added hostless ADB example in sample README.
  - Updated demo URI selector to use wrapping layout (FlowRow) so buttons move to a new line when needed.