### PR TITLE
Overhaul manifest generation (smart path strategy) + add port-aware deeplinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Query parameters are no longer part of `DeeplinkSpec`'s structural regex matcher.
 - `DeeplinkProcessor` now validates typed query params separately after structural URI matching.
 - `DeeplinkProcessor` URI normalization no longer includes query string content.
+- `DeeplinkSpec` now supports optional `port` and includes it in URI matching.
 - `DeeplinkSpec.pathParams` now uses `List<Param>` (instead of `Set<Param>`) so declared path
   segment order is preserved explicitly.
 - Plugin code generation now emits `pathParams = listOf(...)` for generated specs to align with
@@ -19,6 +20,11 @@
 - Plugin code generation now emits a `*DeeplinkParams` class for every deeplink spec, including
   static-only specs with no typed path/query/fragment fields.
 - Plugin config model now treats `host` as optional (`[]` by default), enabling hostless specs.
+- Manifest generation now selects tighter path attributes based on path shape (`path`,
+  `pathPrefix`, `pathPattern`, and `pathAdvancedPattern` on API 31+ builds), and emits dual
+  static-path entries to support trailing slash variants.
+- Generated manifests now include `android:exported="true"` and `tools:node="merge"` on deeplink
+  activities.
 
 ### Fixed
 
@@ -30,6 +36,8 @@
 - Fixed match-result ambiguity for generated processors: static deeplink matches no longer collapse
   to `null` (which was previously indistinguishable from "no match").
 - Fixed hostless deeplink matching (`app:///...`) by explicitly supporting empty-host specs.
+- Fixed manifest generation by removing invalid `android:fragment` output and treating fragment/query
+  constraints as processor-only matching rules.
 - Added build-time validation that every spec declares at least one scheme.
 - Added build-time validation for duplicate deeplink spec names with a clear plugin error message.
 
@@ -39,6 +47,8 @@
 - Updated README/docs to clarify ordered path params list semantics in generated specs.
 - Updated docs to cover `queryParams.required` and generated nullability semantics for optional
   query params.
+- Updated docs to document manifest path strategy, optional `port`, and hostless + trailing-slash
+  manifest behavior.
 
 ### Tests
 
@@ -53,6 +63,8 @@
   `HTTPS://Example.COM/...` and `App://EXAMPLE.com/...`).
 - Added coverage for hostless deeplinks, including regex match, params extraction, and manifest output without `android:host`.
 - Added plugin test coverage for duplicate `name` validation in `.deeplinks.yml`.
+- Added manifest generation coverage for smart path attribute selection, API 31+ advanced path
+  patterns, exported/merge activity attributes, and optional port output.
 
 ## [0.2.0-alpha] - 2026-02-25
 

--- a/buildSrc/src/main/kotlin/com/aouledissa/deepmatch/convention/PublishingExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/aouledissa/deepmatch/convention/PublishingExtensions.kt
@@ -3,7 +3,7 @@ package com.aouledissa.deepmatch.convention
 import org.gradle.api.publish.maven.MavenPom
 
 fun MavenPom.configureDeepMatchPom() {
-    url.set("https://www.deepmatch.aouledissa.com")
+    url.set("https://aouledissa.com/deep-match/")
     licenses {
         license {
             name.set("The Apache License, Version 2.0")

--- a/deepmatch-api/api/deepmatch-api.api
+++ b/deepmatch-api/api/deepmatch-api.api
@@ -3,21 +3,24 @@ public abstract interface class com/aouledissa/deepmatch/api/DeeplinkParams {
 
 public final class com/aouledissa/deepmatch/api/DeeplinkSpec {
 	public static final field Companion Lcom/aouledissa/deepmatch/api/DeeplinkSpec$Companion;
-	public fun <init> (Ljava/util/Set;Ljava/util/Set;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;)V
+	public fun <init> (Ljava/util/Set;Ljava/util/Set;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;)V
+	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Set;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/Set;
 	public final fun component2 ()Ljava/util/Set;
-	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Ljava/util/Set;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Lkotlin/reflect/KClass;
-	public final fun copy (Ljava/util/Set;Ljava/util/Set;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;)Lcom/aouledissa/deepmatch/api/DeeplinkSpec;
-	public static synthetic fun copy$default (Lcom/aouledissa/deepmatch/api/DeeplinkSpec;Ljava/util/Set;Ljava/util/Set;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lcom/aouledissa/deepmatch/api/DeeplinkSpec;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Set;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lkotlin/reflect/KClass;
+	public final fun copy (Ljava/util/Set;Ljava/util/Set;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;)Lcom/aouledissa/deepmatch/api/DeeplinkSpec;
+	public static synthetic fun copy$default (Lcom/aouledissa/deepmatch/api/DeeplinkSpec;Ljava/util/Set;Ljava/util/Set;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lcom/aouledissa/deepmatch/api/DeeplinkSpec;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFragment ()Ljava/lang/String;
 	public final fun getHost ()Ljava/util/Set;
 	public final fun getMatcher ()Lkotlin/text/Regex;
 	public final fun getParametersClass ()Lkotlin/reflect/KClass;
 	public final fun getPathParams ()Ljava/util/List;
+	public final fun getPort ()Ljava/lang/Integer;
 	public final fun getQueryParams ()Ljava/util/Set;
 	public final fun getScheme ()Ljava/util/Set;
 	public fun hashCode ()I

--- a/deepmatch-api/src/main/java/com/aouledissa/deepmatch/api/DeeplinkSpec.kt
+++ b/deepmatch-api/src/main/java/com/aouledissa/deepmatch/api/DeeplinkSpec.kt
@@ -14,6 +14,7 @@ import kotlin.reflect.KClass
 data class DeeplinkSpec(
     val scheme: Set<String>,
     val host: Set<String>,
+    val port: Int? = null,
     val pathParams: List<Param>,
     val queryParams: Set<Param>,
     val fragment: String?,
@@ -36,10 +37,12 @@ data class DeeplinkSpec(
     private fun buildMatcher(): Regex {
         val schemePattern = buildSchemePattern()
         val hostPattern = buildHostPattern()
+        val portPattern = buildPortPattern()
         val pathPattern = buildPathPattern()
         val fragmentPattern = buildFragmentPattern()
 
-        return "$schemePattern://$hostPattern$pathPattern$fragmentPattern".toRegex(RegexOption.IGNORE_CASE)
+        return "$schemePattern://$hostPattern$portPattern$pathPattern$fragmentPattern"
+            .toRegex(RegexOption.IGNORE_CASE)
     }
 
     private fun buildSchemePattern(): String {
@@ -51,6 +54,10 @@ data class DeeplinkSpec(
         if (host.isEmpty()) return ""
         return host.joinToString(separator = "|") { Regex.escape(it) }
             .let { if (host.size > 1) "($it)" else it }
+    }
+
+    private fun buildPortPattern(): String {
+        return port?.let { ":${Regex.escape(it.toString())}" }.orEmpty()
     }
 
     private fun buildPathPattern(): String {

--- a/deepmatch-api/src/test/java/com/aouledissa/deepmatch/api/DeeplinkSpecTest.kt
+++ b/deepmatch-api/src/test/java/com/aouledissa/deepmatch/api/DeeplinkSpecTest.kt
@@ -157,6 +157,22 @@ class DeeplinkSpecTest {
     }
 
     @Test
+    fun `deeplink pattern includes port when provided`() {
+        sut = DeeplinkSpec(
+            scheme = setOf("https"),
+            host = setOf("example.com"),
+            port = 8080,
+            pathParams = listOf(Param(name = "profile")),
+            queryParams = emptySet(),
+            fragment = null,
+            parametersClass = null
+        )
+
+        assertThat(sut.matcher.matches("https://example.com:8080/profile")).isTrue()
+        assertThat(sut.matcher.matches("https://example.com/profile")).isFalse()
+    }
+
+    @Test
     fun `matchesQueryParams returns true regardless of query params order`() {
         // when
         sut = DeeplinkSpec(

--- a/deepmatch-plugin/build.gradle.kts
+++ b/deepmatch-plugin/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 }
 
 gradlePlugin {
-    website = "https://deepmatch.aouledissa.com"
+    website = "https://aouledissa.com/deep-match/"
     vcsUrl = "https://github.com/aouledissa/deep-match"
     plugins {
         create("DeepMatchPlugin") {

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/config/AndroidVariantsConfig.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/config/AndroidVariantsConfig.kt
@@ -1,5 +1,6 @@
 package com.aouledissa.deepmatch.gradle.internal.config
 
+import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import com.aouledissa.deepmatch.gradle.DeepMatchPluginConfig
@@ -12,6 +13,9 @@ import org.gradle.api.file.RegularFile
 
 internal fun configureAndroidVariants(project: Project, config: DeepMatchPluginConfig) {
     val android = project.extensions.getByType(AndroidComponentsExtension::class.java)
+    val compileSdk = (project.extensions.getByName("android") as CommonExtension<*, *, *, *, *, *>)
+        .compileSdk
+        ?: 0
 
     android.onVariants { variant ->
         val specsFile = getSpecsFile(project = project, variant = variant)
@@ -26,6 +30,7 @@ internal fun configureAndroidVariants(project: Project, config: DeepMatchPluginC
             project = project,
             variant = variant,
             specsFile = specsFile,
+            compileSdk = compileSdk,
             generateManifestFiles = config.generateManifestFiles.getOrElse(false)
         )
     }
@@ -65,7 +70,8 @@ private fun registerDeeplinkManifestTask(
     generateManifestFiles: Boolean,
     project: Project,
     variant: Variant,
-    specsFile: RegularFile
+    specsFile: RegularFile,
+    compileSdk: Int
 ) {
     val variantName = variant.name.capitalize()
     val taskName = "generate${variantName}DeeplinksManifest"
@@ -76,6 +82,7 @@ private fun registerDeeplinkManifestTask(
         ) {
             it.specFileProperty.set(specsFile)
             it.outputFile.set(project.layout.buildDirectory.file("generated/manifests/${variantName}"))
+            it.compileSdkProperty.set(compileSdk)
         }
 
         /**

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/model/Manifest.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/model/Manifest.kt
@@ -8,6 +8,8 @@ import kotlinx.serialization.Serializable
 internal data class AndroidManifest(
     @SerialName("xmlns:android")
     val nameSpace: String = "http://schemas.android.com/apk/res/android",
+    @SerialName("xmlns:tools")
+    val toolsNamespace: String = "http://schemas.android.com/tools",
     val application: AndroidApplication,
 )
 
@@ -22,6 +24,10 @@ internal data class AndroidApplication(
 internal data class AndroidActivity(
     @SerialName("android:name")
     val name: String,
+    @SerialName("android:exported")
+    val exported: Boolean = true,
+    @SerialName("tools:node")
+    val mergeStrategy: String = "merge",
     val intentFilter: List<IntentFilter>
 )
 
@@ -34,8 +40,11 @@ internal data class IntentFilter(
     val category: List<Category>,
     val scheme: List<Scheme>,
     val hosts: List<Host>,
-    val pathPattern: PathPattern?,
-    val fragment: Fragment?
+    val port: Port?,
+    val exactPaths: List<ExactPath>,
+    val prefixPaths: List<PrefixPath>,
+    val patternPaths: List<PatternPath>,
+    val advancedPatternPaths: List<AdvancedPatternPath>,
 )
 
 @Serializable
@@ -66,16 +75,41 @@ internal data class Host(
     val name: String
 )
 
-@Serializable
-@SerialName("data")
-internal data class PathPattern(
-    @SerialName("android:pathPattern")
-    val pattern: String
-)
+internal sealed interface PathData
 
 @Serializable
 @SerialName("data")
-internal data class Fragment(
-    @SerialName("android:fragment")
-    val name: String
+internal data class ExactPath(
+    @SerialName("android:path")
+    val path: String
+) : PathData
+
+@Serializable
+@SerialName("data")
+internal data class PrefixPath(
+    @SerialName("android:pathPrefix")
+    val prefix: String
+) : PathData
+
+@Serializable
+@SerialName("data")
+internal data class PatternPath(
+    @SerialName("android:pathPattern")
+    val pattern: String
+) : PathData
+
+@Serializable
+@SerialName("data")
+internal data class AdvancedPatternPath(
+    @SerialName("android:pathAdvancedPattern")
+    val pattern: String,
+    @SerialName("tools:targetApi")
+    val targetApi: String = "31"
+) : PathData
+
+@Serializable
+@SerialName("data")
+internal data class Port(
+    @SerialName("android:port")
+    val number: String
 )

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/model/Specs.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/model/Specs.kt
@@ -16,6 +16,7 @@ internal data class DeeplinkConfig(
     val autoVerify: Boolean = false,
     val scheme: List<String>,
     val host: List<String> = emptyList(),
+    val port: Int? = null,
     val pathParams: List<Param>? = null,
     val queryParams: List<Param>? = null,
     val fragment: String? = null

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkSpecsTask.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkSpecsTask.kt
@@ -170,6 +170,7 @@ internal abstract class GenerateDeeplinkSpecsTask : DefaultTask() {
         )
         val schemes = config.scheme.joinToString(separator = ", ") { "\"$it\"" }
         val hosts = config.host.joinToString(separator = ", ") { "\"$it\"" }
+        val port = config.port?.toString() ?: "null"
         val pathParams = config.pathParams?.joinToString(separator = ", ").orEmpty()
         val queryParams = config.queryParams?.joinToString(separator = ", ").orEmpty()
         val parametersClass = ClassName(packageName, parametersClass)
@@ -189,6 +190,7 @@ internal abstract class GenerateDeeplinkSpecsTask : DefaultTask() {
                 %T(
                 scheme = setOf($schemes),
                 host = setOf($hosts),
+                port = $port,
                 pathParams = listOf($pathParams),
                 queryParams = setOf($queryParams),
                 fragment = ${config.fragment?.let { "\"$it\"" } ?: "null"},
@@ -204,6 +206,7 @@ internal abstract class GenerateDeeplinkSpecsTask : DefaultTask() {
         append(config.scheme)
         append("://")
         append(config.host)
+        config.port?.let { append(":$it") }
         config.pathParams?.map {
             when (it.type) {
                 ParamType.NUMERIC -> "/1234"

--- a/deepmatch-plugin/src/test/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkManifestFileTest.kt
+++ b/deepmatch-plugin/src/test/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkManifestFileTest.kt
@@ -12,32 +12,260 @@ class GenerateDeeplinkManifestFileTest {
     val temporaryFolder = TemporaryFolder()
 
     @Test
+    fun `static path generates exact path entries with trailing slash variant`() {
+        val xml = generateManifest(
+            """
+            deeplinkSpecs:
+              - name: "about page"
+                activity: com.example.app.MainActivity
+                scheme: [https]
+                host: ["example.com"]
+                pathParams:
+                  - name: about
+            """.trimIndent()
+        )
+
+        assertThat(xml).contains("android:path=\"/about\"")
+        assertThat(xml).contains("android:path=\"/about/\"")
+        assertThat(xml).doesNotContain("android:pathPrefix=")
+        assertThat(xml).doesNotContain("android:pathPattern=")
+        assertThat(xml).doesNotContain("android:pathAdvancedPattern=")
+    }
+
+    @Test
+    fun `typed segment at end generates pathPrefix`() {
+        val xml = generateManifest(
+            """
+            deeplinkSpecs:
+              - name: "open profile"
+                activity: com.example.app.MainActivity
+                scheme: [app]
+                host: ["example.com"]
+                pathParams:
+                  - name: users
+                  - name: userId
+                    type: alphanumeric
+            """.trimIndent()
+        )
+
+        assertThat(xml).contains("android:pathPrefix=\"/users/\"")
+        assertThat(xml).doesNotContain("android:pathPattern=")
+    }
+
+    @Test
+    fun `typed segment in middle generates pathPattern and pathAdvancedPattern when compileSdk is 31+`() {
+        val xml = generateManifest(
+            yaml = """
+            deeplinkSpecs:
+              - name: "user posts"
+                activity: com.example.app.MainActivity
+                scheme: [app]
+                host: ["example.com"]
+                pathParams:
+                  - name: users
+                  - name: userId
+                    type: numeric
+                  - name: posts
+            """.trimIndent(),
+            compileSdk = 34
+        )
+
+        assertThat(xml).contains("android:pathPattern=\"/users/.*/posts\"")
+        assertThat(xml).contains("android:pathAdvancedPattern=\"/users/[^/]+/posts\"")
+        assertThat(xml).contains("tools:targetApi=\"31\"")
+    }
+
+    @Test
+    fun `typed segment in middle generates only pathPattern when compileSdk is below 31`() {
+        val xml = generateManifest(
+            yaml = """
+            deeplinkSpecs:
+              - name: "user posts"
+                activity: com.example.app.MainActivity
+                scheme: [app]
+                host: ["example.com"]
+                pathParams:
+                  - name: users
+                  - name: userId
+                    type: numeric
+                  - name: posts
+            """.trimIndent(),
+            compileSdk = 30
+        )
+
+        assertThat(xml).contains("android:pathPattern=\"/users/.*/posts\"")
+        assertThat(xml).doesNotContain("android:pathAdvancedPattern=")
+    }
+
+    @Test
+    fun `all typed path generates only advanced pattern on compileSdk 31+`() {
+        val xml = generateManifest(
+            yaml = """
+            deeplinkSpecs:
+              - name: "dynamic route"
+                activity: com.example.app.MainActivity
+                scheme: [app]
+                host: ["example.com"]
+                pathParams:
+                  - name: section
+                    type: string
+                  - name: itemId
+                    type: numeric
+            """.trimIndent(),
+            compileSdk = 34
+        )
+
+        assertThat(xml).contains("android:pathAdvancedPattern=\"/[^/]+/[^/]+\"")
+        assertThat(xml).doesNotContain("android:pathPattern=")
+        assertThat(xml).doesNotContain("android:pathPrefix=")
+        assertThat(xml).doesNotContain("android:path=\"")
+    }
+
+    @Test
+    fun `all typed path omits path attributes when compileSdk is below 31`() {
+        val xml = generateManifest(
+            yaml = """
+            deeplinkSpecs:
+              - name: "dynamic route"
+                activity: com.example.app.MainActivity
+                scheme: [app]
+                host: ["example.com"]
+                pathParams:
+                  - name: section
+                    type: string
+                  - name: itemId
+                    type: numeric
+            """.trimIndent(),
+            compileSdk = 30
+        )
+
+        assertThat(xml).doesNotContain("android:path=\"")
+        assertThat(xml).doesNotContain("android:pathPrefix=")
+        assertThat(xml).doesNotContain("android:pathPattern=")
+        assertThat(xml).doesNotContain("android:pathAdvancedPattern=")
+    }
+
+    @Test
     fun `hostless spec does not generate android host attribute`() {
+        val xml = generateManifest(
+            """
+            deeplinkSpecs:
+              - name: "open profile"
+                activity: com.example.app.MainActivity
+                scheme: [app]
+                pathParams:
+                  - name: profile
+                  - name: profileId
+                    type: numeric
+            """.trimIndent()
+        )
+
+        assertThat(xml).contains("android:scheme=\"app\"")
+        assertThat(xml).doesNotContain("android:host=")
+    }
+
+    @Test
+    fun `fragment and query params are not written to manifest`() {
+        val xml = generateManifest(
+            """
+            deeplinkSpecs:
+              - name: "open profile"
+                activity: com.example.app.MainActivity
+                scheme: [https]
+                host: ["example.com"]
+                pathParams:
+                  - name: users
+                  - name: userId
+                    type: alphanumeric
+                queryParams:
+                  - name: ref
+                    type: string
+                fragment: "details"
+            """.trimIndent()
+        )
+
+        assertThat(xml).doesNotContain("android:fragment=")
+        assertThat(xml).doesNotContain("android:query")
+    }
+
+    @Test
+    fun `autoVerify true includes default and browsable categories`() {
+        val xml = generateManifest(
+            """
+            deeplinkSpecs:
+              - name: "verify profile"
+                activity: com.example.app.MainActivity
+                scheme: [https]
+                host: ["example.com"]
+                autoVerify: true
+                categories: [DEFAULT]
+            """.trimIndent()
+        )
+
+        assertThat(xml).contains("android:autoVerify=\"true\"")
+        assertThat(xml).contains("android:name=\"android.intent.category.DEFAULT\"")
+        assertThat(xml).contains("android:name=\"android.intent.category.BROWSABLE\"")
+    }
+
+    @Test
+    fun `activity includes exported true and merge strategy`() {
+        val xml = generateManifest(
+            """
+            deeplinkSpecs:
+              - name: "open profile"
+                activity: com.example.app.MainActivity
+                scheme: [app]
+                host: ["example.com"]
+            """.trimIndent()
+        )
+
+        assertThat(xml).contains("xmlns:tools=\"http://schemas.android.com/tools\"")
+        assertThat(xml).contains("android:exported=\"true\"")
+        assertThat(xml).contains("tools:node=\"merge\"")
+    }
+
+    @Test
+    fun `port is generated when provided and omitted otherwise`() {
+        val withPort = generateManifest(
+            """
+            deeplinkSpecs:
+              - name: "staging profile"
+                activity: com.example.app.MainActivity
+                scheme: [https]
+                host: ["staging.example.com"]
+                port: 8080
+            """.trimIndent()
+        )
+        val withoutPort = generateManifest(
+            """
+            deeplinkSpecs:
+              - name: "prod profile"
+                activity: com.example.app.MainActivity
+                scheme: [https]
+                host: ["example.com"]
+            """.trimIndent()
+        )
+
+        assertThat(withPort).contains("android:port=\"8080\"")
+        assertThat(withoutPort).doesNotContain("android:port=")
+    }
+
+    private fun generateManifest(yaml: String, compileSdk: Int = 34): String {
         val project = ProjectBuilder.builder().build()
-        val specsFile = temporaryFolder.newFile("hostless-manifest.deeplinks.yml").apply {
-            writeText(
-                """
-                deeplinkSpecs:
-                  - name: "open profile"
-                    activity: com.example.app.MainActivity
-                    scheme: [app]
-                    pathParams:
-                      - name: profile
-                      - name: profileId
-                        type: numeric
-                """.trimIndent()
-            )
+        val specsFile = temporaryFolder.newFile("manifest-${System.nanoTime()}.deeplinks.yml").apply {
+            writeText(yaml)
         }
-        val outputManifest = temporaryFolder.newFile("AndroidManifest.xml")
-        val task = project.tasks.register("generateManifest", GenerateDeeplinkManifestFile::class.java).get()
+        val outputManifest = temporaryFolder.newFile("AndroidManifest-${System.nanoTime()}.xml")
+        val task = project.tasks.register(
+            "generateManifest${System.nanoTime()}",
+            GenerateDeeplinkManifestFile::class.java
+        ).get()
 
         task.specFileProperty.set(project.layout.file(project.provider { specsFile }))
         task.outputFile.set(project.layout.file(project.provider { outputManifest }))
+        task.compileSdkProperty.set(compileSdk)
 
         task.generateDeeplinkManifest()
-
-        val xml = outputManifest.readText()
-        assertThat(xml).contains("android:scheme=\"app\"")
-        assertThat(xml).doesNotContain("android:host=")
+        return outputManifest.readText()
     }
 }

--- a/deepmatch-processor/src/main/java/com/aouledissa/deepmatch/processor/DeeplinkProcessor.kt
+++ b/deepmatch-processor/src/main/java/com/aouledissa/deepmatch/processor/DeeplinkProcessor.kt
@@ -30,7 +30,8 @@ open class DeeplinkProcessor(
             .trimEnd('/')
             .let { if (pathSegments.isNullOrEmpty().not()) "/$it" else it }
         val decodedFragment = fragment?.let { "#$it" }.orEmpty()
-        return "$scheme://${host.orEmpty()}$decodedPathSegments$decodedFragment"
+        val decodedPort = if (port >= 0) ":$port" else ""
+        return "$scheme://${host.orEmpty()}$decodedPort$decodedPathSegments$decodedFragment"
     }
 
     private fun buildDeeplinkParams(

--- a/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorRobolectricTest.kt
+++ b/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorRobolectricTest.kt
@@ -253,6 +253,26 @@ class DeeplinkProcessorRobolectricTest {
         assertThat(params?.profileId).isEqualTo(123)
     }
 
+    @Test
+    fun deeplinkWithPort_matchesOnlyWhenPortMatchesSpec() {
+        val spec = DeeplinkSpec(
+            scheme = setOf("https"),
+            host = setOf("example.com"),
+            port = 8080,
+            pathParams = listOf(Param(name = "profile")),
+            queryParams = emptySet(),
+            fragment = null,
+            parametersClass = HomeParams::class
+        )
+        val processor = DeeplinkProcessor(specs = setOf(spec))
+
+        val matching = processor.match(Uri.parse("https://example.com:8080/profile"))
+        val nonMatching = processor.match(Uri.parse("https://example.com/profile"))
+
+        assertThat(matching).isInstanceOf(HomeParams::class.java)
+        assertThat(nonMatching).isNull()
+    }
+
     data class SeriesParams(
         val seriesId: Int,
         val ref: String?,

--- a/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorTest.kt
+++ b/deepmatch-processor/src/test/java/com/aouledissa/deepmatch/processor/DeeplinkProcessorTest.kt
@@ -30,6 +30,7 @@ class DeeplinkProcessorTest {
         val uri = mockk<Uri>(relaxed = true)
         every { uri.scheme } returns "app"
         every { uri.host } returns "example.com"
+        every { uri.port } returns -1
         every { uri.pathSegments } returns listOf("series", "42")
         every { uri.query } returns "ref=promo"
         every { uri.fragment } returns "trailer-tab"
@@ -61,6 +62,7 @@ class DeeplinkProcessorTest {
         val uri = mockk<Uri>(relaxed = true)
         every { uri.scheme } returns "app"
         every { uri.host } returns "other.com"
+        every { uri.port } returns -1
         every { uri.pathSegments } returns emptyList()
         every { uri.query } returns null
         every { uri.fragment } returns null
@@ -86,6 +88,7 @@ class DeeplinkProcessorTest {
         val uri = mockk<Uri>(relaxed = true)
         every { uri.scheme } returns "app"
         every { uri.host } returns "example.com"
+        every { uri.port } returns -1
         every { uri.pathSegments } returns emptyList()
         every { uri.query } returns null
         every { uri.fragment } returns null
@@ -111,6 +114,7 @@ class DeeplinkProcessorTest {
         val uri = mockk<Uri>(relaxed = true)
         every { uri.scheme } returns "app"
         every { uri.host } returns "example.com"
+        every { uri.port } returns -1
         every { uri.pathSegments } returns listOf("home")
         every { uri.query } returns null
         every { uri.fragment } returns null

--- a/deepmatch-testing/api/deepmatch-testing.api
+++ b/deepmatch-testing/api/deepmatch-testing.api
@@ -1,7 +1,7 @@
 public final class com/aouledissa/deepmatch/api/DeeplinkSpecFixtures {
 	public static final field INSTANCE Lcom/aouledissa/deepmatch/api/DeeplinkSpecFixtures;
-	public final fun create (Ljava/util/Set;Ljava/util/Set;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;)Lcom/aouledissa/deepmatch/api/DeeplinkSpec;
-	public static synthetic fun create$default (Lcom/aouledissa/deepmatch/api/DeeplinkSpecFixtures;Ljava/util/Set;Ljava/util/Set;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lcom/aouledissa/deepmatch/api/DeeplinkSpec;
+	public final fun create (Ljava/util/Set;Ljava/util/Set;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;)Lcom/aouledissa/deepmatch/api/DeeplinkSpec;
+	public static synthetic fun create$default (Lcom/aouledissa/deepmatch/api/DeeplinkSpecFixtures;Ljava/util/Set;Ljava/util/Set;Ljava/lang/Integer;Ljava/util/List;Ljava/util/Set;Ljava/lang/String;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lcom/aouledissa/deepmatch/api/DeeplinkSpec;
 }
 
 public final class com/aouledissa/deepmatch/processor/FakeDeeplinkProcessor : com/aouledissa/deepmatch/processor/DeeplinkProcessor {

--- a/deepmatch-testing/src/main/kotlin/com/aouledissa/deepmatch/api/DeeplinkSpecFixtures.kt
+++ b/deepmatch-testing/src/main/kotlin/com/aouledissa/deepmatch/api/DeeplinkSpecFixtures.kt
@@ -7,6 +7,7 @@ object DeeplinkSpecFixtures {
     fun create(
         scheme: Set<String> = setOf(),
         host: Set<String> = setOf(),
+        port: Int? = null,
         pathParams: List<Param> = emptyList(),
         queryParams: Set<Param> = setOf(),
         fragment: String? = null,
@@ -15,6 +16,7 @@ object DeeplinkSpecFixtures {
         return DeeplinkSpec(
             scheme = scheme,
             host = host,
+            port = port,
             pathParams = pathParams,
             queryParams = queryParams,
             fragment = fragment,

--- a/docs/deeplink-specs.md
+++ b/docs/deeplink-specs.md
@@ -56,6 +56,15 @@ Each item in the deeplinkSpecs list is a deep link configuration object with the
       host: ["example.com", "m.example.com"]
       ```
 
+- `port`
+    - Type: Integer
+    - Required: No
+    - Description: Optional URI port filter (for example staging links on `:8080`).
+    - Example:
+      ```yaml
+      port: 8080
+      ```
+
 - `pathParams`
     - Type: List of Param
     - Required: No
@@ -134,7 +143,7 @@ Each item in the deeplinkSpecs list is a deep link configuration object with the
 - `fragment`
     - Type: String
     - Required: No
-    - Description: Required URI fragment (#...). Exposed in generated params when declared.
+    - Description: Required URI fragment (#...). Exposed in generated params when declared. Fragment matching is runtime-only (not manifest-level).
     - Example:
       ```yaml
       fragment: "details"
@@ -160,6 +169,7 @@ deeplinkSpecs:
     categories: [DEFAULT, BROWSABLE]
     scheme: [https, app]
     host: ["example.com"]
+    port: 8080
     pathParams:
       - name: users
       - name: userId
@@ -183,5 +193,6 @@ deeplinkSpecs:
 - Query params are optional by default; set `required: true` only for values that must be present.
 - Scheme and host matching are case-insensitive, so values like `HTTPS://Example.COM/...` still match `scheme: [https]` and `host: ["example.com"]`.
 - `scheme` must contain at least one value. `host` can be omitted (or set to `[]`) for hostless URIs.
+- Manifest generation does not filter by query params or fragment; those are validated by the runtime processor.
 - All generated params classes implement a module-level sealed interface named from the module name (for example, module `app` -> `AppDeeplinkParams`), enabling exhaustive `when` checks.
 - The plugin also generates a module-level processor object named from the module name (for example, module `app` -> `AppDeeplinkProcessor`) preloaded with all generated specs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ Typed query params are validated by key and type, so query ordering does not mat
 For example, `?ref=promo&page=1` and `?page=1&ref=promo` are treated the same.
 Query params are optional by default; use `required: true` for mandatory keys.
 Path params are ordered and matched by position as declared in YAML.
+If `port` is declared, it is matched at runtime and emitted in generated manifest filters.
 
 5. Generate sources (or run a normal build):
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -13,6 +13,13 @@ The primary responsibilities and capabilities of the DeepMatch Gradle plugin are
 2.  **Android Manifest Generation:**
     *   Based on the parsed `deeplinkSpecs` from your YAML file, the plugin dynamically generates the necessary `<intent-filter>` entries within your app's `AndroidManifest.xml`.
     *   For each `DeeplinkConfig` entry in your YAML, it creates an `<activity>` (or merges with an existing one if the `activity` name matches) and adds an `<intent-filter>` to it.
+    *   Path attributes are selected automatically based on spec shape:
+        *   static paths -> `android:path` (with trailing-slash variant)
+        *   typed-at-end paths -> `android:pathPrefix`
+        *   typed-in-middle paths -> `android:pathPattern` (+ `android:pathAdvancedPattern` when `compileSdk >= 31`)
+    *   Hostless specs omit `android:host`. When `port` is declared, `android:port` is generated.
+    *   Query params and fragment constraints are not emitted in manifest filters (they are runtime-validated by `DeeplinkProcessor`).
+    *   Generated deeplink activities include `android:exported="true"` and `tools:node="merge"` for Android 12+ and merge-friendly behavior.
     *   This automation means you **do not need to manually write or maintain these `<intent-filter>` tags** in your main `AndroidManifest.xml` for the deep links defined in your YAML. The plugin handles keeping them in sync with your YAML configuration.
     *   The generated manifest entries are typically merged into the final manifest during the build process (e.g., visible in `app/build/intermediates/merged_manifests/debug/AndroidManifest.xml`).
 

--- a/samples/android-app/.deeplinks.yml
+++ b/samples/android-app/.deeplinks.yml
@@ -35,3 +35,22 @@ deeplinkSpecs:
       - name: profile
       - name: profileId
         type: numeric
+
+  - name: "open about"
+    activity: com.aouledissa.deepmatch.sample.MainActivity
+    categories: [DEFAULT, BROWSABLE]
+    scheme: [app]
+    host: ["sample.deepmatch.dev"]
+    pathParams:
+      - name: about
+
+  - name: "open user posts"
+    activity: com.aouledissa.deepmatch.sample.MainActivity
+    categories: [DEFAULT, BROWSABLE]
+    scheme: [app]
+    host: ["sample.deepmatch.dev"]
+    pathParams:
+      - name: users
+      - name: userId
+        type: numeric
+      - name: posts

--- a/samples/android-app/README.md
+++ b/samples/android-app/README.md
@@ -46,8 +46,23 @@ adb shell am start -W \
   -d "app:///profile/123"
 ```
 
+```bash
+adb shell am start -W \
+  -a android.intent.action.VIEW \
+  -c android.intent.category.BROWSABLE \
+  -d "app://sample.deepmatch.dev/about/"
+```
+
+```bash
+adb shell am start -W \
+  -a android.intent.action.VIEW \
+  -c android.intent.category.BROWSABLE \
+  -d "app://sample.deepmatch.dev/users/42/posts"
+```
+
 The screen should render parsed output for `OpenSeriesDeeplinkParams`, `OpenProfileDeeplinkParams`,
-and `OpenHostlessProfileDeeplinkParams`.
+`OpenHostlessProfileDeeplinkParams`, `OpenAboutDeeplinkParams`, and
+`OpenUserPostsDeeplinkParams`.
 
 In this sample:
 - `open series` keeps `ref` optional.

--- a/samples/android-app/src/main/java/com/aouledissa/deepmatch/sample/MainActivity.kt
+++ b/samples/android-app/src/main/java/com/aouledissa/deepmatch/sample/MainActivity.kt
@@ -42,9 +42,11 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import com.aouledissa.deepmatch.sample.deeplinks.AppDeeplinkParams
 import com.aouledissa.deepmatch.sample.deeplinks.AppDeeplinkProcessor
+import com.aouledissa.deepmatch.sample.deeplinks.OpenAboutDeeplinkParams
 import com.aouledissa.deepmatch.sample.deeplinks.OpenHostlessProfileDeeplinkParams
 import com.aouledissa.deepmatch.sample.deeplinks.OpenProfileDeeplinkParams
 import com.aouledissa.deepmatch.sample.deeplinks.OpenSeriesDeeplinkParams
+import com.aouledissa.deepmatch.sample.deeplinks.OpenUserPostsDeeplinkParams
 
 class MainActivity : ComponentActivity() {
 
@@ -92,6 +94,24 @@ private fun DeeplinkResultScreen(uri: Uri) {
             accent = Color(0xFF7C3AED),
             properties = listOf(
                 "profileId" to result.profileId.toString()
+            )
+        )
+
+        is OpenAboutDeeplinkParams -> MatchUi(
+            title = "Static Path Deeplink",
+            subtitle = "Matched exact static path",
+            accent = Color(0xFF9A3412),
+            properties = listOf(
+                "path" to "/about"
+            )
+        )
+
+        is OpenUserPostsDeeplinkParams -> MatchUi(
+            title = "Typed-Middle Deeplink",
+            subtitle = "Matched path with typed segment in the middle",
+            accent = Color(0xFF0F766E),
+            properties = listOf(
+                "userId" to result.userId.toString()
             )
         )
 
@@ -295,6 +315,8 @@ private enum class DemoUri(
         label = "Profile",
         uri = "app://sample.deepmatch.dev/profile/john123?ref=demo#details"
     ),
+    About(label = "About", uri = "app://sample.deepmatch.dev/about/"),
+    UserPosts(label = "User Posts", uri = "app://sample.deepmatch.dev/users/42/posts"),
     Hostless(label = "Hostless", uri = "app:///profile/123"),
     Series(label = "Series", uri = "app://sample.deepmatch.dev/series/42?ref=home"),
     NoMatch(label = "No Match", uri = "app://sample.deepmatch.dev/unknown");
@@ -302,7 +324,9 @@ private enum class DemoUri(
 
 private fun detectDemoUri(uri: Uri): DemoUri {
     return when (val params = AppDeeplinkProcessor.match(uri) as? AppDeeplinkParams) {
+        is OpenAboutDeeplinkParams -> DemoUri.About
         is OpenProfileDeeplinkParams -> DemoUri.Profile
+        is OpenUserPostsDeeplinkParams -> DemoUri.UserPosts
         is OpenHostlessProfileDeeplinkParams -> DemoUri.Hostless
         is OpenSeriesDeeplinkParams -> DemoUri.Series
         null -> DemoUri.NoMatch


### PR DESCRIPTION
## Summary

  This PR refactors manifest generation to produce tighter and safer intent filters, while keeping processor matching as the final authority. It also adds optional port support end-
  to-end and updates the sample/docs.

  ## What Changed

  - Manifest model/task:
      - removed invalid android:fragment emission
      - added android:exported="true" and tools:node="merge" on generated activities
      - added optional android:port support
      - added smart path selection:
          - static paths -> exact android:path (+ trailing slash variant)
          - typed-at-end -> android:pathPrefix
          - typed-in-middle -> android:pathPattern (+ android:pathAdvancedPattern when compileSdk >= 31)
          - all-typed -> advanced pattern only on API 31+ builds
      - hostless specs omit android:host
  - API/runtime:
      - added port: Int? to DeeplinkSpec
      - matcher/processor URI normalization now includes port matching
  - Plugin codegen/model:
      - DeeplinkConfig now supports port
      - generated DeeplinkSpec includes port
      - manifest task receives compileSdk from Android config
  - Sample:
      - added minimal demo specs/URIs for static path and typed-in-middle path manifest cases
  - Docs/changelog:
      - documented manifest strategy, port field, and processor-vs-manifest responsibilities
      - updated sample README ADB examples
      - added Unreleased changelog entries