### PR TITLE
Improve Task registration

### DIFF
--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/config/AndroidVariantsConfig.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/config/AndroidVariantsConfig.kt
@@ -36,9 +36,7 @@ import org.gradle.api.tasks.TaskProvider
 
 internal fun configureAndroidVariants(project: Project, config: DeepMatchPluginConfig) {
     val android = project.extensions.getByType(AndroidComponentsExtension::class.java)
-    val compileSdk = (project.extensions.getByName("android") as CommonExtension)
-        .compileSdk
-        ?: 0
+    val compileSdk = (project.extensions.getByName("android") as CommonExtension).compileSdk ?: 0
 
     android.onVariants { variant ->
         val specsFiles = getSpecsFiles(project = project, variant = variant)
@@ -194,7 +192,7 @@ private fun registerDeeplinkSpecsSourcesTask(
      * This api will automatically add the sources to the variant's main sourceSet,
      * and also make the variant build pipeline depend on this task.
      */
-    variant.sources.java?.addGeneratedSourceDirectory(
+    variant.sources.kotlin?.addGeneratedSourceDirectory(
         generateVariantDeeplinkSpecsTask,
         GenerateDeeplinkSpecsTask::outputDir
     )
@@ -333,7 +331,8 @@ private fun registerDeeplinkManifestTask(
         ) {
             it.specFileProperty.set(specsFile)
             it.additionalSpecsFilesProperty.setFrom(additionalSpecsFiles)
-            it.outputFile.set(project.layout.buildDirectory.file("generated/manifests/${variantName}"))
+            it.outputFile.set(project.layout.buildDirectory.file("generated/manifests/${taskName}/AndroidManifest.xml"))
+            it.outputDir.set(project.layout.buildDirectory.dir("generated/manifests/$taskName"))
             it.compileSdkProperty.set(compileSdk)
             it.group = "deepmatch"
             it.description =
@@ -347,6 +346,10 @@ private fun registerDeeplinkManifestTask(
         variant.sources.manifests.addGeneratedManifestFile(
             generateVariantManifestFile,
             GenerateDeeplinkManifestFile::outputFile
+        )
+        variant.sources.kotlin?.addGeneratedSourceDirectory(
+            generateVariantManifestFile,
+            GenerateDeeplinkManifestFile::outputDir
         )
     } else {
         val fileToDelete = project.layout.buildDirectory.dir("generated/manifests/$taskName")

--- a/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkManifestFile.kt
+++ b/deepmatch-plugin/src/main/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkManifestFile.kt
@@ -38,11 +38,13 @@ import com.charleskorn.kaml.YamlConfiguration
 import nl.adaptivity.xmlutil.serialization.XML
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
@@ -56,6 +58,9 @@ internal abstract class GenerateDeeplinkManifestFile : DefaultTask() {
 
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
 
     @get:Input
     abstract val compileSdkProperty: Property<Int>
@@ -124,7 +129,8 @@ internal abstract class GenerateDeeplinkManifestFile : DefaultTask() {
         val manifest = AndroidManifest(application = AndroidApplication(activity = activities))
         val manifestXmlCode = xmlSerializer.encodeToString(AndroidManifest.serializer(), manifest)
         val manifestFile = outputFile.asFile.get()
-        manifestFile.writeText(manifestXmlCode)
+        val xmlWithHeader = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n$manifestXmlCode"
+        manifestFile.writeText(xmlWithHeader)
     }
 
     private fun getFilterCategories(

--- a/deepmatch-plugin/src/test/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkManifestFileTest.kt
+++ b/deepmatch-plugin/src/test/java/com/aouledissa/deepmatch/gradle/internal/task/GenerateDeeplinkManifestFileTest.kt
@@ -270,6 +270,21 @@ class GenerateDeeplinkManifestFileTest {
     }
 
     @Test
+    fun `generated manifest includes xml declaration`() {
+        val xml = generateManifest(
+            """
+            deeplinkSpecs:
+              - name: "open profile"
+                activity: com.example.app.MainActivity
+                scheme: [app]
+                host: ["example.com"]
+            """.trimIndent()
+        )
+
+        assertThat(xml).startsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+    }
+
+    @Test
     fun `port is generated when provided and omitted otherwise`() {
         val withPort = generateManifest(
             """
@@ -321,6 +336,7 @@ class GenerateDeeplinkManifestFileTest {
             )
         }
         val outputManifest = temporaryFolder.newFile("AndroidManifest-${System.nanoTime()}.xml")
+        val outputDir = outputManifest.parentFile
         val task = project.tasks.register(
             "generateManifestMultiFile${System.nanoTime()}",
             GenerateDeeplinkManifestFile::class.java
@@ -331,6 +347,7 @@ class GenerateDeeplinkManifestFileTest {
             project.layout.file(project.provider { extraSpecsFile })
         )
         task.outputFile.set(project.layout.file(project.provider { outputManifest }))
+        task.outputDir.set(project.layout.dir(project.provider { outputDir }))
         task.compileSdkProperty.set(34)
 
         task.generateDeeplinkManifest()
@@ -346,6 +363,7 @@ class GenerateDeeplinkManifestFileTest {
             writeText(yaml)
         }
         val outputManifest = temporaryFolder.newFile("AndroidManifest-${System.nanoTime()}.xml")
+        val outputDir = outputManifest.parentFile
         val task = project.tasks.register(
             "generateManifest${System.nanoTime()}",
             GenerateDeeplinkManifestFile::class.java
@@ -353,6 +371,7 @@ class GenerateDeeplinkManifestFileTest {
 
         task.specFileProperty.set(project.layout.file(project.provider { specsFile }))
         task.outputFile.set(project.layout.file(project.provider { outputManifest }))
+        task.outputDir.set(project.layout.dir(project.provider { outputDir }))
         task.compileSdkProperty.set(compileSdk)
 
         task.generateDeeplinkManifest()


### PR DESCRIPTION
- register tasks to kotlin source-set instead of java.
- add generated manifest into kotlin source set.
- add missing xml header in generated manifest.